### PR TITLE
Improved Error Representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,18 +712,18 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -987,6 +987,7 @@ dependencies = [
  "serde_repr",
  "smarty-rust-proc-macro",
  "task-local-extensions",
+ "thiserror",
  "tokio",
  "url",
 ]
@@ -1019,9 +1020,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1082,18 +1083,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/smarty-rust-proc-macro/src/lib.rs
+++ b/smarty-rust-proc-macro/src/lib.rs
@@ -158,7 +158,7 @@ fn impl_smarty_api_macro(attrs: &MacroArgs, ast: &mut syn::DeriveInput) -> Token
                     /// Uses the lookup and the client in
                     /// order to build a request and send the message
                     /// to the server.
-                    async fn send_lookup(&self, lookup: &mut #lookup_type) -> Result<(), SDKError> {
+                    async fn send_lookup(&self, lookup: &mut #lookup_type) -> Result<(), SmartyError> {
                         let mut req = self
                             .client
                             .reqwest_client
@@ -176,7 +176,7 @@ fn impl_smarty_api_macro(attrs: &MacroArgs, ast: &mut syn::DeriveInput) -> Token
                     /// Uses a batch and the client in
                     /// Order to build a request
                     /// that will handle the batch
-                    pub async fn send(&self, batch: &mut Batch<#lookup_type>) -> Result<(), SDKError> {
+                    pub async fn send(&self, batch: &mut Batch<#lookup_type>) -> Result<(), SmartyError> {
                         if batch.is_empty() {
                             return Ok(())
                         }
@@ -206,7 +206,7 @@ fn impl_smarty_api_macro(attrs: &MacroArgs, ast: &mut syn::DeriveInput) -> Token
                     /// Uses the lookup and the client in
                     /// order to build a request and send the message
                     /// to the server.
-                    pub async fn send(&self, lookup: &mut #lookup_type) -> Result<(), SDKError> {
+                    pub async fn send(&self, lookup: &mut #lookup_type) -> Result<(), SmartyError> {
                         let mut req = self
                             .client
                             .reqwest_client

--- a/smarty-rust-sdk/Cargo.toml
+++ b/smarty-rust-sdk/Cargo.toml
@@ -24,6 +24,7 @@ url = "2.4.1"
 smarty-rust-proc-macro = {path="../smarty-rust-proc-macro", version="0.0.0"} # This version will be replaced at publish time, Do not change it.
 anyhow = "1.0.75"
 hyper = "0.14.27"
+thiserror = "1.0.58"
 
 [dev-dependencies]
 futures = "0.3.28"

--- a/smarty-rust-sdk/examples/international_autocomplete_api.rs
+++ b/smarty-rust-sdk/examples/international_autocomplete_api.rs
@@ -22,11 +22,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new()
-        .authenticate(authentication)
+    let options = OptionsBuilder::new(authentication)
         .with_license("international-autocomplete-v2-cloud")
-        .build()
-        .unwrap();
+        .build();
 
     let client = InternationalAutocompleteClient::new(options)?;
 

--- a/smarty-rust-sdk/examples/international_autocomplete_api.rs
+++ b/smarty-rust-sdk/examples/international_autocomplete_api.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new(authentication)
+    let options = OptionsBuilder::new(Some(authentication))
         .with_license("international-autocomplete-v2-cloud")
         .build();
 

--- a/smarty-rust-sdk/examples/international_street_api.rs
+++ b/smarty-rust-sdk/examples/international_street_api.rs
@@ -27,11 +27,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new()
+    let options = OptionsBuilder::new(authentication)
         .with_license("international-global-plus-cloud")
-        .authenticate(authentication)
-        .build()
-        .unwrap();
+        .build();
 
     let client = InternationalStreetClient::new(options)?;
 

--- a/smarty-rust-sdk/examples/international_street_api.rs
+++ b/smarty-rust-sdk/examples/international_street_api.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new(authentication)
+    let options = OptionsBuilder::new(Some(authentication))
         .with_license("international-global-plus-cloud")
         .build();
 

--- a/smarty-rust-sdk/examples/logger.rs
+++ b/smarty-rust-sdk/examples/logger.rs
@@ -41,13 +41,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Create the options from it's builder pattern
-    let options = OptionsBuilder::new()
+    let options = OptionsBuilder::new(authentication)
         .with_license("us-core-cloud")
         .with_logging()
         .with_retries(2)
-        .authenticate(authentication)
-        .build()
-        .unwrap();
+        .build();
 
     // Setup the logger
     // To better learn, look at (https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/log.html)

--- a/smarty-rust-sdk/examples/logger.rs
+++ b/smarty-rust-sdk/examples/logger.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Create the options from it's builder pattern
-    let options = OptionsBuilder::new(authentication)
+    let options = OptionsBuilder::new(Some(authentication))
         .with_license("us-core-cloud")
         .with_logging()
         .with_retries(2)

--- a/smarty-rust-sdk/examples/us_autocomplete_pro_api.rs
+++ b/smarty-rust-sdk/examples/us_autocomplete_pro_api.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new(authentication)
+    let options = OptionsBuilder::new(Some(authentication))
         .with_license("us-autocomplete-pro-cloud")
         .build();
 

--- a/smarty-rust-sdk/examples/us_autocomplete_pro_api.rs
+++ b/smarty-rust-sdk/examples/us_autocomplete_pro_api.rs
@@ -27,11 +27,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new()
+    let options = OptionsBuilder::new(authentication)
         .with_license("us-autocomplete-pro-cloud")
-        .authenticate(authentication)
-        .build()
-        .unwrap();
+        .build();
 
     let client = USAutocompleteProClient::new(options)?;
     client.send(lookup).await?;

--- a/smarty-rust-sdk/examples/us_enrichment_api.rs
+++ b/smarty-rust-sdk/examples/us_enrichment_api.rs
@@ -2,12 +2,13 @@ use smarty_rust_sdk::sdk::authentication::SecretKeyCredential;
 use smarty_rust_sdk::sdk::options::OptionsBuilder;
 use smarty_rust_sdk::us_enrichment_api::client::USEnrichmentClient;
 use smarty_rust_sdk::us_enrichment_api::lookup::EnrichmentLookup;
-use smarty_rust_sdk::us_enrichment_api::results::{EnrichmentResponse, FinancialResponse, PrincipalResponse};
+use smarty_rust_sdk::us_enrichment_api::results::{
+    EnrichmentResponse, FinancialResponse, PrincipalResponse,
+};
 use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-
     let key = 7;
 
     lookup::<FinancialResponse>(key).await?;
@@ -24,12 +25,10 @@ async fn lookup<R: EnrichmentResponse>(key: u32) -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new()
+    let options = OptionsBuilder::new(authentication)
         .with_license(&format!("us-property-data-{}-cloud", R::lookup_type()))
         .with_logging()
-        .authenticate(authentication)
-        .build()
-        .unwrap();
+        .build();
 
     let client = USEnrichmentClient::new(options)?;
 

--- a/smarty-rust-sdk/examples/us_enrichment_api.rs
+++ b/smarty-rust-sdk/examples/us_enrichment_api.rs
@@ -25,7 +25,7 @@ async fn lookup<R: EnrichmentResponse>(key: u32) -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new(authentication)
+    let options = OptionsBuilder::new(Some(authentication))
         .with_license(&format!("us-property-data-{}-cloud", R::lookup_type()))
         .with_logging()
         .build();

--- a/smarty-rust-sdk/examples/us_extract_api.rs
+++ b/smarty-rust-sdk/examples/us_extract_api.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new(authentication)
+    let options = OptionsBuilder::new(Some(authentication))
         .with_license("us-core-cloud")
         .with_logging()
         .build();

--- a/smarty-rust-sdk/examples/us_extract_api.rs
+++ b/smarty-rust-sdk/examples/us_extract_api.rs
@@ -27,12 +27,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new()
+    let options = OptionsBuilder::new(authentication)
         .with_license("us-core-cloud")
         .with_logging()
-        .authenticate(authentication)
-        .build()
-        .unwrap();
+        .build();
 
     let client = USExtractClient::new(options)?;
 

--- a/smarty-rust-sdk/examples/us_reverse_geo_api.rs
+++ b/smarty-rust-sdk/examples/us_reverse_geo_api.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new(authentication)
+    let options = OptionsBuilder::new(Some(authentication))
         .with_license("us-reverse-geocoding-cloud")
         .build();
 

--- a/smarty-rust-sdk/examples/us_reverse_geo_api.rs
+++ b/smarty-rust-sdk/examples/us_reverse_geo_api.rs
@@ -22,11 +22,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new()
+    let options = OptionsBuilder::new(authentication)
         .with_license("us-reverse-geocoding-cloud")
-        .authenticate(authentication)
-        .build()
-        .unwrap();
+        .build();
 
     let client = USReverseGeoClient::new(options)?;
 

--- a/smarty-rust-sdk/examples/us_street_api.rs
+++ b/smarty-rust-sdk/examples/us_street_api.rs
@@ -36,11 +36,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new()
+    let options = OptionsBuilder::new(authentication)
         .with_license("us-core-cloud")
-        .authenticate(authentication)
-        .build()
-        .unwrap();
+        .build();
 
     let client = USStreetAddressClient::new(options)?;
 

--- a/smarty-rust-sdk/examples/us_street_api.rs
+++ b/smarty-rust-sdk/examples/us_street_api.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new(authentication)
+    let options = OptionsBuilder::new(Some(authentication))
         .with_license("us-core-cloud")
         .build();
 

--- a/smarty-rust-sdk/examples/us_street_multithread.rs
+++ b/smarty-rust-sdk/examples/us_street_multithread.rs
@@ -42,12 +42,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Set Up The Options Here
-    let options = OptionsBuilder::new()
+    let options = OptionsBuilder::new(authentication)
         .with_license("us-core-cloud")
         .with_logging()
-        .authenticate(authentication)
-        .build()
-        .unwrap();
+        .build();
 
     let client = Arc::new(USStreetAddressClient::new(options).expect("Failed to create client"));
 

--- a/smarty-rust-sdk/examples/us_street_multithread.rs
+++ b/smarty-rust-sdk/examples/us_street_multithread.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Set Up The Options Here
-    let options = OptionsBuilder::new(authentication)
+    let options = OptionsBuilder::new(Some(authentication))
         .with_license("us-core-cloud")
         .with_logging()
         .build();

--- a/smarty-rust-sdk/examples/us_zipcode_api.rs
+++ b/smarty-rust-sdk/examples/us_zipcode_api.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new(authentication)
+    let options = OptionsBuilder::new(Some(authentication))
         .with_license("us-core-cloud")
         .build();
 

--- a/smarty-rust-sdk/examples/us_zipcode_api.rs
+++ b/smarty-rust-sdk/examples/us_zipcode_api.rs
@@ -32,11 +32,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         std::env::var("SMARTY_AUTH_TOKEN").expect("Missing SMARTY_AUTH_TOKEN env variable"),
     );
 
-    let options = OptionsBuilder::new()
+    let options = OptionsBuilder::new(authentication)
         .with_license("us-core-cloud")
-        .authenticate(authentication)
-        .build()
-        .unwrap();
+        .build();
 
     let client = USZipcodeClient::new(options)?;
 

--- a/smarty-rust-sdk/src/international_autocomplete_api/client.rs
+++ b/smarty-rust-sdk/src/international_autocomplete_api/client.rs
@@ -1,7 +1,7 @@
 use crate::international_autocomplete_api::lookup::Lookup;
 use crate::international_autocomplete_api::suggestion::SuggestionListing;
 use crate::sdk::client::Client;
-use crate::sdk::error::SDKError;
+use crate::sdk::error::SmartyError;
 use crate::sdk::options::Options;
 use crate::sdk::send_request;
 use reqwest::Method;
@@ -22,18 +22,10 @@ impl InternationalAutocompleteClient {
     /// Uses the lookup and the client in
     /// order to build a request and send the message
     /// to the server.
-    pub async fn send(&self, lookup: &mut Lookup) -> Result<(), SDKError> {
+    pub async fn send(&self, lookup: &mut Lookup) -> Result<(), SmartyError> {
         let mut url = self.client.url.clone();
         if lookup.address_id != String::default() {
-            match url.join(&lookup.address_id) {
-                Ok(value) => url = value,
-                Err(err) => {
-                    return Err(SDKError {
-                        code: None,
-                        detail: Some(err.to_string()),
-                    })
-                }
-            }
+            url = url.join(&lookup.address_id)?;
         }
         let mut req = self.client.reqwest_client.request(Method::GET, url);
         req = self.client.build_request(req);

--- a/smarty-rust-sdk/src/international_autocomplete_api/mod.rs
+++ b/smarty-rust-sdk/src/international_autocomplete_api/mod.rs
@@ -6,15 +6,12 @@ pub mod suggestion;
 mod tests {
     use crate::international_autocomplete_api::client::InternationalAutocompleteClient;
     use crate::international_autocomplete_api::lookup::Lookup;
-    use crate::sdk::authentication::SecretKeyCredential;
     use crate::sdk::options::OptionsBuilder;
 
     #[test]
     fn client_test() {
-        let client = InternationalAutocompleteClient::new(
-            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
-        )
-        .unwrap();
+        let client =
+            InternationalAutocompleteClient::new(OptionsBuilder::new(None).build()).unwrap();
 
         assert_eq!(
             client.client.url.to_string(),

--- a/smarty-rust-sdk/src/international_autocomplete_api/mod.rs
+++ b/smarty-rust-sdk/src/international_autocomplete_api/mod.rs
@@ -12,10 +12,7 @@ mod tests {
     #[test]
     fn client_test() {
         let client = InternationalAutocompleteClient::new(
-            OptionsBuilder::new()
-                .authenticate(SecretKeyCredential::new("".to_string(), "".to_string()))
-                .build()
-                .unwrap(),
+            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
         )
         .unwrap();
 

--- a/smarty-rust-sdk/src/international_street_api/client.rs
+++ b/smarty-rust-sdk/src/international_street_api/client.rs
@@ -1,7 +1,7 @@
 use crate::international_street_api::candidate::Candidate;
 use crate::international_street_api::lookup::Lookup;
 use crate::sdk::client::Client;
-use crate::sdk::error::SDKError;
+use crate::sdk::error::SmartyError;
 use crate::sdk::options::Options;
 use crate::sdk::send_request;
 use reqwest::Method;

--- a/smarty-rust-sdk/src/international_street_api/mod.rs
+++ b/smarty-rust-sdk/src/international_street_api/mod.rs
@@ -12,10 +12,7 @@ mod tests {
     #[test]
     fn client_test() {
         let client = InternationalStreetClient::new(
-            OptionsBuilder::new()
-                .authenticate(SecretKeyCredential::new("".to_string(), "".to_string()))
-                .build()
-                .unwrap(),
+            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
         )
         .unwrap();
 

--- a/smarty-rust-sdk/src/international_street_api/mod.rs
+++ b/smarty-rust-sdk/src/international_street_api/mod.rs
@@ -6,15 +6,11 @@ pub mod lookup;
 mod tests {
     use crate::international_street_api::client::InternationalStreetClient;
     use crate::international_street_api::lookup::Lookup;
-    use crate::sdk::authentication::SecretKeyCredential;
     use crate::sdk::options::OptionsBuilder;
 
     #[test]
     fn client_test() {
-        let client = InternationalStreetClient::new(
-            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
-        )
-        .unwrap();
+        let client = InternationalStreetClient::new(OptionsBuilder::new(None).build()).unwrap();
 
         assert_eq!(
             client.client.url.to_string(),

--- a/smarty-rust-sdk/src/sdk/authentication.rs
+++ b/smarty-rust-sdk/src/sdk/authentication.rs
@@ -13,7 +13,6 @@ pub trait Authenticate: Sync + Send + Debug + AuthClone {
     fn authenticate(&self, request: RequestBuilder) -> RequestBuilder;
 }
 
-// TODO: Doc String
 #[derive(Clone, PartialEq, Debug)]
 pub struct SecretKeyCredential {
     pub auth_id: String,
@@ -44,7 +43,6 @@ impl Authenticate for SecretKeyCredential {
     }
 }
 
-// TODO: Doc String
 #[derive(Clone, PartialEq, Debug)]
 pub struct WebsiteKeyCredential {
     key: String,

--- a/smarty-rust-sdk/src/sdk/batch.rs
+++ b/smarty-rust-sdk/src/sdk/batch.rs
@@ -1,5 +1,6 @@
-use crate::sdk::error::SDKError;
 use crate::sdk::MAX_BATCH_SIZE;
+
+use thiserror::Error;
 
 #[derive(Clone)]
 /// A storage for lookups.
@@ -14,14 +15,15 @@ impl<T> Default for Batch<T> {
     }
 }
 
+#[derive(Error, Debug)]
+#[error("Batch is full")]
+pub struct BatchError;
+
 impl<T> Batch<T> {
     /// Pushes a lookup into the batch, returns an SDKError if the batch is full.
-    pub fn push(&mut self, lookup: T) -> Result<(), SDKError> {
+    pub fn push(&mut self, lookup: T) -> Result<(), BatchError> {
         if self.is_full() {
-            return Err(SDKError {
-                code: None,
-                detail: Some(format!("Batch is full (max {})", MAX_BATCH_SIZE)),
-            });
+            return Err(BatchError);
         }
 
         self.lookups.push(lookup);

--- a/smarty-rust-sdk/src/sdk/client.rs
+++ b/smarty-rust-sdk/src/sdk/client.rs
@@ -41,7 +41,9 @@ impl Client {
     }
 
     pub(crate) fn build_request(&self, mut builder: RequestBuilder) -> RequestBuilder {
-        builder = self.options.authentication.authenticate(builder);
+        if let Some(auth) = &self.options.authentication {
+            builder = auth.authenticate(builder);
+        }
 
         builder = builder.query(&[("license".to_string(), self.options.license.clone())]);
 

--- a/smarty-rust-sdk/src/sdk/error.rs
+++ b/smarty-rust-sdk/src/sdk/error.rs
@@ -10,8 +10,6 @@ pub enum SmartyError {
     Middleware(#[from] anyhow::Error),
     #[error("failed to parse url")]
     Parse(#[from] url::ParseError),
-    #[error("authentication required")]
-    AuthError,
-    #[error("http failed to send")]
+    #[error("http error")]
     HttpError { code: StatusCode, detail: String },
 }

--- a/smarty-rust-sdk/src/sdk/error.rs
+++ b/smarty-rust-sdk/src/sdk/error.rs
@@ -1,22 +1,17 @@
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use hyper::StatusCode;
+use thiserror::Error;
 
-#[derive(Debug, Clone)]
-
-/// An error returned by a struct in the SDK.
-pub struct SDKError {
-    pub code: Option<u16>,
-    pub detail: Option<String>,
+/// An error returned by a smarty api.
+#[derive(Debug, Error)]
+pub enum SmartyError {
+    #[error("failed to process request")]
+    RequestProcess(#[from] reqwest::Error),
+    #[error("request middleware failed")]
+    Middleware(#[from] anyhow::Error),
+    #[error("failed to parse url")]
+    Parse(#[from] url::ParseError),
+    #[error("authentication required")]
+    AuthError,
+    #[error("http failed to send")]
+    HttpError { code: StatusCode, detail: String },
 }
-
-impl Display for SDKError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "SDK Error: ErrorCode: {:?}\nDetails: {:?}",
-            self.code, self.detail
-        )
-    }
-}
-
-impl Error for SDKError {}

--- a/smarty-rust-sdk/src/sdk/mod.rs
+++ b/smarty-rust-sdk/src/sdk/mod.rs
@@ -117,7 +117,7 @@ mod tests {
     fn client_test() {
         let client = Client::new(
             "https://www.smarty.com".parse().unwrap(),
-            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
+            OptionsBuilder::new(None).build(),
             "docs",
         )
         .unwrap();

--- a/smarty-rust-sdk/src/sdk/mod.rs
+++ b/smarty-rust-sdk/src/sdk/mod.rs
@@ -1,4 +1,4 @@
-use crate::sdk::error::SDKError;
+use crate::sdk::error::SmartyError;
 use reqwest_middleware::RequestBuilder;
 use serde::de::DeserializeOwned;
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -36,40 +36,26 @@ impl Display for CoordinateLicense {
     }
 }
 
-pub(crate) async fn send_request<C>(request: RequestBuilder) -> Result<C, SDKError>
+pub(crate) async fn send_request<C>(request: RequestBuilder) -> Result<C, SmartyError>
 where
     C: DeserializeOwned,
 {
-    let response = match request.send().await {
-        Ok(response) => response,
-        Err(error) => {
-            return Err(SDKError {
-                code: None,
-                detail: Some(format!("{:?}", error)),
-            });
-        }
-    };
+    let response = request.send().await.map_err(|e| match e {
+        reqwest_middleware::Error::Middleware(e) => SmartyError::from(e),
+        reqwest_middleware::Error::Reqwest(e) => SmartyError::from(e),
+    })?;
 
     if !response.status().is_success() {
         let status_code = response.status();
-        let body = match response.text().await {
-            Ok(body) => body,
-            Err(_) => "Could not read body for response".to_string(),
-        };
+        let body = response.text().await?;
 
-        return Err(SDKError {
-            code: Some(status_code.as_u16()),
-            detail: Some(body),
+        return Err(SmartyError::HttpError {
+            code: status_code,
+            detail: body,
         });
     }
 
-    match response.json::<C>().await {
-        Ok(candidates) => Ok(candidates),
-        Err(err) => Err(SDKError {
-            code: None,
-            detail: Some(format!("{:?}", err)),
-        }),
-    }
+    Ok(response.json::<C>().await?)
 }
 
 /// This is only used for Serializing for post
@@ -78,35 +64,14 @@ pub(crate) fn is_zero(num: &i64) -> bool {
     *num == 0
 }
 
-pub(crate) fn has_param(name: String, param: String) -> Option<(String, String)> {
-    if param != String::default() {
-        Some((name, param))
-    } else {
-        None
-    }
-}
-
-pub(crate) fn has_i32_param(name: String, param: i32, default: i32) -> Option<(String, String)> {
-    if param == default {
-        None
-    } else {
+pub(crate) fn has_param<P: PartialEq + Display + Default>(
+    name: String,
+    param: P,
+) -> Option<(String, String)> {
+    if param != P::default() {
         Some((name, param.to_string()))
-    }
-}
-
-pub(crate) fn has_f64_param(name: String, param: f64, default: f64) -> Option<(String, String)> {
-    if param == default {
-        None
     } else {
-        Some((name, param.to_string()))
-    }
-}
-
-pub(crate) fn has_bool_param(name: String, param: bool, default: bool) -> Option<(String, String)> {
-    if param == default {
         None
-    } else {
-        Some((name, param.to_string()))
     }
 }
 
@@ -152,10 +117,7 @@ mod tests {
     fn client_test() {
         let client = Client::new(
             "https://www.smarty.com".parse().unwrap(),
-            OptionsBuilder::new()
-                .authenticate(SecretKeyCredential::new("".to_string(), "".to_string()))
-                .build()
-                .unwrap(),
+            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
             "docs",
         )
         .unwrap();

--- a/smarty-rust-sdk/src/sdk/options.rs
+++ b/smarty-rust-sdk/src/sdk/options.rs
@@ -1,7 +1,5 @@
 use crate::sdk::authentication::Authenticate;
 
-use super::error::SDKError;
-
 /// A builder for the options
 ///
 /// Example:
@@ -20,38 +18,33 @@ pub struct OptionsBuilder {
     num_retries: u64,
     logging_enabled: bool,
     headers: Vec<(String, String)>,
-    authentication: Option<Box<dyn Authenticate>>,
+    authentication: Box<dyn Authenticate>,
 }
 
 // Allowing this because it is a builder pattern
 #[allow(clippy::new_without_default)]
 impl OptionsBuilder {
-    pub fn new() -> Self {
+    /// Creates a new OptionsBuilder, taking in the authentication for the options.
+    pub fn new(authentication: Box<dyn Authenticate>) -> Self {
         Self {
             license: "".to_string(),
             num_retries: 10,
             logging_enabled: false,
             headers: vec![],
-            authentication: None,
+            authentication,
         }
     }
 
     /// Builds the builder into options with the parameters you set
     /// Returns an error if authentication is not set
-    pub fn build(self) -> Result<Options, SDKError> {
-        if let Some(auth) = self.authentication {
-            return Ok(Options {
-                license: self.license,
-                num_retries: self.num_retries,
-                logging_enabled: self.logging_enabled,
-                headers: self.headers,
-                authentication: auth,
-            });
+    pub fn build(self) -> Options {
+        Options {
+            license: self.license,
+            num_retries: self.num_retries,
+            logging_enabled: self.logging_enabled,
+            headers: self.headers,
+            authentication: self.authentication,
         }
-        Err(SDKError {
-            code: None,
-            detail: Some("Authentication Required".to_string()),
-        })
     }
 
     /// Adds a license string to the options
@@ -75,12 +68,6 @@ impl OptionsBuilder {
     /// Adds a set of custom headers to your request.
     pub fn with_headers(mut self, headers: Vec<(String, String)>) -> Self {
         self.headers = headers;
-        self
-    }
-
-    /// Inserts the authentication into the options.
-    pub fn authenticate(mut self, authentication: Box<dyn Authenticate>) -> Self {
-        self.authentication = Some(authentication);
         self
     }
 }

--- a/smarty-rust-sdk/src/sdk/options.rs
+++ b/smarty-rust-sdk/src/sdk/options.rs
@@ -6,12 +6,10 @@ use crate::sdk::authentication::Authenticate;
 /// ```ignore
 /// let authentication = SecretKeyCredential::new("test".to_string(), "test".to_string());
 ///
-/// OptionsBuilder::new()
+/// OptionsBuilder::new(authentication)
 ///     .with_license("test_license")
 ///     .with_logging()
-///     .authenticate(authentication)
 ///     .build()
-///     .expect("Authentication failed")
 /// ```
 pub struct OptionsBuilder {
     license: String,

--- a/smarty-rust-sdk/src/sdk/options.rs
+++ b/smarty-rust-sdk/src/sdk/options.rs
@@ -16,14 +16,14 @@ pub struct OptionsBuilder {
     num_retries: u64,
     logging_enabled: bool,
     headers: Vec<(String, String)>,
-    authentication: Box<dyn Authenticate>,
+    authentication: Option<Box<dyn Authenticate>>,
 }
 
 // Allowing this because it is a builder pattern
 #[allow(clippy::new_without_default)]
 impl OptionsBuilder {
     /// Creates a new OptionsBuilder, taking in the authentication for the options.
-    pub fn new(authentication: Box<dyn Authenticate>) -> Self {
+    pub fn new(authentication: Option<Box<dyn Authenticate>>) -> Self {
         Self {
             license: "".to_string(),
             num_retries: 10,
@@ -88,7 +88,7 @@ pub struct Options {
     pub(crate) headers: Vec<(String, String)>,
 
     // Authentication
-    pub(crate) authentication: Box<dyn Authenticate>,
+    pub(crate) authentication: Option<Box<dyn Authenticate>>,
 }
 
 impl Clone for Options {
@@ -98,7 +98,7 @@ impl Clone for Options {
             num_retries: self.num_retries,
             logging_enabled: self.logging_enabled,
             headers: self.headers.clone(),
-            authentication: self.authentication.clone_box(),
+            authentication: self.authentication.as_ref().map(|x| x.clone_box()),
         }
     }
 }

--- a/smarty-rust-sdk/src/us_autocomplete_api/client.rs
+++ b/smarty-rust-sdk/src/us_autocomplete_api/client.rs
@@ -1,5 +1,5 @@
 use crate::sdk::client::Client;
-use crate::sdk::error::SDKError;
+use crate::sdk::error::SmartyError;
 use crate::sdk::options::Options;
 use crate::sdk::send_request;
 use crate::us_autocomplete_api::lookup::Lookup;

--- a/smarty-rust-sdk/src/us_autocomplete_api/lookup.rs
+++ b/smarty-rust-sdk/src/us_autocomplete_api/lookup.rs
@@ -1,4 +1,4 @@
-use crate::sdk::{has_f64_param, has_i32_param, has_param, has_vec_param};
+use crate::sdk::{has_param, has_vec_param};
 use crate::us_autocomplete_api::suggestion::SuggestionListing;
 use serde::Serialize;
 
@@ -37,12 +37,12 @@ impl Lookup {
     pub(crate) fn into_param_array(self) -> Vec<(String, String)> {
         vec![
             has_param("prefix".to_string(), self.prefix),
-            has_i32_param("max_suggestions".to_string(), self.max_suggestions, 0),
+            has_param("max_suggestions".to_string(), self.max_suggestions),
             has_vec_param("city_filter".to_string(), ",", self.city_filter),
             has_vec_param("state_filter".to_string(), ",", self.state_filter),
             has_vec_param("preferences".to_string(), ",", self.preferences),
             self.geolocation.geolocation_to_param(),
-            has_f64_param("prefer_ratio".to_string(), self.prefer_ratio, 0.0),
+            has_param("prefer_ratio".to_string(), self.prefer_ratio),
         ]
         .iter()
         .filter_map(Option::clone)

--- a/smarty-rust-sdk/src/us_autocomplete_api/mod.rs
+++ b/smarty-rust-sdk/src/us_autocomplete_api/mod.rs
@@ -12,10 +12,7 @@ mod tests {
     #[test]
     fn client_test() {
         let client = USAutocompleteClient::new(
-            OptionsBuilder::new()
-                .authenticate(SecretKeyCredential::new("".to_string(), "".to_string()))
-                .build()
-                .unwrap(),
+            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
         )
         .unwrap();
 

--- a/smarty-rust-sdk/src/us_autocomplete_api/mod.rs
+++ b/smarty-rust-sdk/src/us_autocomplete_api/mod.rs
@@ -4,17 +4,13 @@ pub mod suggestion;
 
 #[cfg(test)]
 mod tests {
-    use crate::sdk::authentication::SecretKeyCredential;
     use crate::sdk::options::OptionsBuilder;
     use crate::us_autocomplete_api::client::USAutocompleteClient;
     use crate::us_autocomplete_api::lookup::Lookup;
 
     #[test]
     fn client_test() {
-        let client = USAutocompleteClient::new(
-            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
-        )
-        .unwrap();
+        let client = USAutocompleteClient::new(OptionsBuilder::new(None).build()).unwrap();
 
         assert_eq!(
             client.client.url.to_string(),

--- a/smarty-rust-sdk/src/us_autocomplete_pro_api/client.rs
+++ b/smarty-rust-sdk/src/us_autocomplete_pro_api/client.rs
@@ -1,5 +1,5 @@
 use crate::sdk::client::Client;
-use crate::sdk::error::SDKError;
+use crate::sdk::error::SmartyError;
 use crate::sdk::options::Options;
 use crate::sdk::send_request;
 use crate::us_autocomplete_pro_api::lookup::Lookup;

--- a/smarty-rust-sdk/src/us_autocomplete_pro_api/lookup.rs
+++ b/smarty-rust-sdk/src/us_autocomplete_pro_api/lookup.rs
@@ -1,4 +1,4 @@
-use crate::sdk::{has_i32_param, has_param, has_vec_param};
+use crate::sdk::{has_param, has_vec_param};
 use crate::us_autocomplete_pro_api::suggestion::SuggestionListing;
 use serde::Serialize;
 
@@ -49,14 +49,14 @@ impl Lookup {
         vec![
             has_param("search".to_string(), self.search),
             has_param("source".to_string(), self.source),
-            has_i32_param("max_results".to_string(), self.max_results, 0),
+            has_param("max_results".to_string(), self.max_results),
             has_vec_param("include_only_cities".to_string(), ";", self.city_filter),
             has_vec_param("include_only_states".to_string(), ";", self.state_filter),
             has_vec_param("include_only_zip_codes".to_string(), ";", self.zip_filter),
             has_vec_param("exclude_states".to_string(), ";", self.exclude_states),
             has_vec_param("prefer_states".to_string(), ";", self.prefer_state),
             has_vec_param("prefer_zip_codes".to_string(), ";", self.prefer_zip),
-            has_i32_param("prefer_ratio".to_string(), self.prefer_ratio, 0),
+            has_param("prefer_ratio".to_string(), self.prefer_ratio),
             geolocation_self.geolocation_param(),
         ]
         .iter()

--- a/smarty-rust-sdk/src/us_autocomplete_pro_api/mod.rs
+++ b/smarty-rust-sdk/src/us_autocomplete_pro_api/mod.rs
@@ -4,17 +4,13 @@ pub mod suggestion;
 
 #[cfg(test)]
 mod tests {
-    use crate::sdk::authentication::SecretKeyCredential;
     use crate::sdk::options::OptionsBuilder;
     use crate::us_autocomplete_pro_api::client::USAutocompleteProClient;
     use crate::us_autocomplete_pro_api::lookup::{Geolocation, Lookup};
 
     #[test]
     fn client_test() {
-        let client = USAutocompleteProClient::new(
-            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
-        )
-        .unwrap();
+        let client = USAutocompleteProClient::new(OptionsBuilder::new(None).build()).unwrap();
 
         assert_eq!(
             client.client.url.to_string(),

--- a/smarty-rust-sdk/src/us_autocomplete_pro_api/mod.rs
+++ b/smarty-rust-sdk/src/us_autocomplete_pro_api/mod.rs
@@ -12,10 +12,7 @@ mod tests {
     #[test]
     fn client_test() {
         let client = USAutocompleteProClient::new(
-            OptionsBuilder::new()
-                .authenticate(SecretKeyCredential::new("".to_string(), "".to_string()))
-                .build()
-                .unwrap(),
+            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
         )
         .unwrap();
 

--- a/smarty-rust-sdk/src/us_enrichment_api/client.rs
+++ b/smarty-rust-sdk/src/us_enrichment_api/client.rs
@@ -1,5 +1,5 @@
 use crate::sdk::client::Client;
-use crate::sdk::error::SDKError;
+use crate::sdk::error::SmartyError;
 use crate::sdk::options::Options;
 use crate::sdk::send_request;
 use crate::us_enrichment_api::lookup::EnrichmentLookup;
@@ -26,17 +26,14 @@ impl USEnrichmentClient {
     pub async fn send<R: EnrichmentResponse + DeserializeOwned>(
         &self,
         lookup: &mut EnrichmentLookup<R>,
-    ) -> Result<(), SDKError> {
+    ) -> Result<(), SmartyError> {
         let mut url = self.client.url.clone();
-        match url.join(&format!("/lookup/{}/property/{}", lookup.smarty_key, R::lookup_type())) {
-            Ok(value) => url = value,
-            Err(err) => {
-                return Err(SDKError {
-                    code: None,
-                    detail: Some(err.to_string()),
-                })
-            }
-        }
+        url = url.join(&format!(
+            "/lookup/{}/property/{}",
+            lookup.smarty_key,
+            R::lookup_type()
+        ))?;
+
         let mut req = self.client.reqwest_client.request(Method::GET, url);
         req = self.client.build_request(req);
 

--- a/smarty-rust-sdk/src/us_enrichment_api/mod.rs
+++ b/smarty-rust-sdk/src/us_enrichment_api/mod.rs
@@ -11,10 +11,8 @@ mod tests {
 
     #[test]
     fn client_test() {
-        let options = OptionsBuilder::new()
-            .authenticate(SecretKeyCredential::new("".to_string(), "".to_string()))
-            .build()
-            .unwrap();
+        let options =
+            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build();
         let client = USEnrichmentClient::new(options).unwrap();
 
         assert_eq!(

--- a/smarty-rust-sdk/src/us_enrichment_api/mod.rs
+++ b/smarty-rust-sdk/src/us_enrichment_api/mod.rs
@@ -4,15 +4,11 @@ pub mod results;
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        sdk::{authentication::SecretKeyCredential, options::OptionsBuilder},
-        us_enrichment_api::client::USEnrichmentClient,
-    };
+    use crate::{sdk::options::OptionsBuilder, us_enrichment_api::client::USEnrichmentClient};
 
     #[test]
     fn client_test() {
-        let options =
-            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build();
+        let options = OptionsBuilder::new(None).build();
         let client = USEnrichmentClient::new(options).unwrap();
 
         assert_eq!(

--- a/smarty-rust-sdk/src/us_extract_api/client.rs
+++ b/smarty-rust-sdk/src/us_extract_api/client.rs
@@ -1,5 +1,5 @@
 use crate::sdk::client::Client;
-use crate::sdk::error::SDKError;
+use crate::sdk::error::SmartyError;
 use crate::sdk::options::Options;
 use crate::sdk::send_request;
 use crate::us_extract_api::lookup::Lookup;
@@ -18,7 +18,7 @@ use url::{ParseError, Url};
 pub struct USExtractClient;
 
 impl USExtractClient {
-    pub async fn send(&self, lookup: &mut Lookup) -> Result<(), SDKError> {
+    pub async fn send(&self, lookup: &mut Lookup) -> Result<(), SmartyError> {
         let mut req = self
             .client
             .reqwest_client

--- a/smarty-rust-sdk/src/us_extract_api/lookup.rs
+++ b/smarty-rust-sdk/src/us_extract_api/lookup.rs
@@ -1,4 +1,4 @@
-use crate::sdk::{has_bool_param, has_i32_param, has_param};
+use crate::sdk::has_param;
 use crate::us_extract_api::extraction::ExtractionResult;
 use crate::us_street_api::lookup::MatchStrategy;
 use serde::Serialize;
@@ -37,13 +37,12 @@ impl Lookup {
     pub(crate) fn into_param_array(self) -> Vec<(String, String)> {
         vec![
             has_param("html".to_string(), self.html.to_string()),
-            has_bool_param("aggressive".to_string(), self.aggressive, false),
-            has_bool_param(
+            has_param("aggressive".to_string(), self.aggressive),
+            has_param(
                 "addr_line_breaks".to_string(),
                 self.addresses_with_line_breaks,
-                false,
             ),
-            has_i32_param("addr_per_line".to_string(), self.addresses_per_line, 0),
+            has_param("addr_per_line".to_string(), self.addresses_per_line),
             has_param("match".to_string(), self.match_strategy.to_string()),
         ]
         .iter()

--- a/smarty-rust-sdk/src/us_extract_api/mod.rs
+++ b/smarty-rust-sdk/src/us_extract_api/mod.rs
@@ -12,10 +12,7 @@ mod tests {
     #[test]
     fn client_test() {
         let client = USExtractClient::new(
-            OptionsBuilder::new()
-                .authenticate(SecretKeyCredential::new("".to_string(), "".to_string()))
-                .build()
-                .unwrap(),
+            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
         )
         .unwrap();
 

--- a/smarty-rust-sdk/src/us_extract_api/mod.rs
+++ b/smarty-rust-sdk/src/us_extract_api/mod.rs
@@ -4,17 +4,13 @@ pub mod lookup;
 
 #[cfg(test)]
 mod tests {
-    use crate::sdk::authentication::SecretKeyCredential;
     use crate::sdk::options::OptionsBuilder;
     use crate::us_extract_api::client::USExtractClient;
     use crate::us_extract_api::lookup::Lookup;
 
     #[test]
     fn client_test() {
-        let client = USExtractClient::new(
-            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
-        )
-        .unwrap();
+        let client = USExtractClient::new(OptionsBuilder::new(None).build()).unwrap();
 
         assert_eq!(
             client.client.url.to_string(),

--- a/smarty-rust-sdk/src/us_reverse_geo_api/client.rs
+++ b/smarty-rust-sdk/src/us_reverse_geo_api/client.rs
@@ -1,5 +1,5 @@
 use crate::sdk::client::Client;
-use crate::sdk::error::SDKError;
+use crate::sdk::error::SmartyError;
 use crate::sdk::options::Options;
 use crate::sdk::send_request;
 use crate::us_reverse_geo_api::address::Results;

--- a/smarty-rust-sdk/src/us_reverse_geo_api/mod.rs
+++ b/smarty-rust-sdk/src/us_reverse_geo_api/mod.rs
@@ -12,10 +12,7 @@ mod tests {
     #[test]
     fn client_test() {
         let client = USReverseGeoClient::new(
-            OptionsBuilder::new()
-                .authenticate(SecretKeyCredential::new("".to_string(), "".to_string()))
-                .build()
-                .unwrap(),
+            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
         )
         .unwrap();
 

--- a/smarty-rust-sdk/src/us_reverse_geo_api/mod.rs
+++ b/smarty-rust-sdk/src/us_reverse_geo_api/mod.rs
@@ -4,17 +4,13 @@ pub mod lookup;
 
 #[cfg(test)]
 mod tests {
-    use crate::sdk::authentication::SecretKeyCredential;
     use crate::sdk::options::OptionsBuilder;
     use crate::us_reverse_geo_api::client::USReverseGeoClient;
     use crate::us_reverse_geo_api::lookup::Lookup;
 
     #[test]
     fn client_test() {
-        let client = USReverseGeoClient::new(
-            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
-        )
-        .unwrap();
+        let client = USReverseGeoClient::new(OptionsBuilder::new(None).build()).unwrap();
 
         assert_eq!(
             client.client.url.to_string(),

--- a/smarty-rust-sdk/src/us_street_api/client.rs
+++ b/smarty-rust-sdk/src/us_street_api/client.rs
@@ -4,7 +4,7 @@ use reqwest::Method;
 use smarty_rust_proc_macro::smarty_api;
 use url::{ParseError, Url};
 
-use crate::sdk::error::SDKError;
+use crate::sdk::error::SmartyError;
 use crate::sdk::options::Options;
 use crate::sdk::send_request;
 use crate::us_street_api::candidate::Candidates;

--- a/smarty-rust-sdk/src/us_street_api/mod.rs
+++ b/smarty-rust-sdk/src/us_street_api/mod.rs
@@ -14,10 +14,7 @@ mod tests {
     #[test]
     fn client_test() {
         let client = USStreetAddressClient::new(
-            OptionsBuilder::new()
-                .authenticate(SecretKeyCredential::new("".to_string(), "".to_string()))
-                .build()
-                .unwrap(),
+            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
         )
         .unwrap();
 

--- a/smarty-rust-sdk/src/us_street_api/mod.rs
+++ b/smarty-rust-sdk/src/us_street_api/mod.rs
@@ -5,7 +5,6 @@ pub mod candidate;
 
 #[cfg(test)]
 mod tests {
-    use crate::sdk::authentication::SecretKeyCredential;
     use crate::sdk::batch::Batch;
     use crate::sdk::options::OptionsBuilder;
     use crate::us_street_api::client::USStreetAddressClient;
@@ -13,10 +12,7 @@ mod tests {
 
     #[test]
     fn client_test() {
-        let client = USStreetAddressClient::new(
-            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build(),
-        )
-        .unwrap();
+        let client = USStreetAddressClient::new(OptionsBuilder::new(None).build()).unwrap();
 
         assert_eq!(
             client.client.url.to_string(),

--- a/smarty-rust-sdk/src/us_zipcode_api/client.rs
+++ b/smarty-rust-sdk/src/us_zipcode_api/client.rs
@@ -1,6 +1,6 @@
 use crate::sdk::batch::Batch;
 use crate::sdk::client::Client;
-use crate::sdk::error::SDKError;
+use crate::sdk::error::SmartyError;
 use crate::sdk::options::Options;
 use crate::sdk::send_request;
 use crate::us_zipcode_api::candidate::ZipcodeResult;

--- a/smarty-rust-sdk/src/us_zipcode_api/mod.rs
+++ b/smarty-rust-sdk/src/us_zipcode_api/mod.rs
@@ -15,10 +15,8 @@ mod tests {
 
     #[test]
     fn client_test() {
-        let options = OptionsBuilder::new()
-            .authenticate(SecretKeyCredential::new("".to_string(), "".to_string()))
-            .build()
-            .unwrap();
+        let options =
+            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build();
         let client = USZipcodeClient::new(options).unwrap();
 
         assert_eq!(

--- a/smarty-rust-sdk/src/us_zipcode_api/mod.rs
+++ b/smarty-rust-sdk/src/us_zipcode_api/mod.rs
@@ -7,7 +7,6 @@ pub mod candidate;
 // Tests
 #[cfg(test)]
 mod tests {
-    use crate::sdk::authentication::SecretKeyCredential;
     use crate::sdk::batch::Batch;
     use crate::sdk::options::OptionsBuilder;
     use crate::us_zipcode_api::client::USZipcodeClient;
@@ -15,8 +14,7 @@ mod tests {
 
     #[test]
     fn client_test() {
-        let options =
-            OptionsBuilder::new(SecretKeyCredential::new("".to_string(), "".to_string())).build();
+        let options = OptionsBuilder::new(None).build();
         let client = USZipcodeClient::new(options).unwrap();
 
         assert_eq!(


### PR DESCRIPTION
# Changelog
- Adjusted the `has_param` function to use generics.
- Adjusted `OptionsBuilder` to ensure that it can't fail.
- Renamed `SDKError` to `SmartyError`
- Changed the `SmartyError` type to be an enum and that will allow for catching errors for user side.

# Reasoning
Before, using the sdk without panicking didn't work very well, when anything went wrong, the error type failed you, as catching a simple error was extremely difficult. Using an enum type for the error handling forces a set number of error types (excluding the HTTP Error Enum) Allowing for users to catch these errors and handle them.

Handling HTTP Errors has been improved as it now stores the StatusCode type instead of a u16, and the StatusCode type has better abilities to check why a failure may have occurred, so recovering from errors has been improved.