### PR TITLE
fix: Incorrect named field should be predirection not prediction

### DIFF
--- a/smarty-rust-sdk/src/us_street_api/candidate.rs
+++ b/smarty-rust-sdk/src/us_street_api/candidate.rs
@@ -25,8 +25,8 @@ pub struct Candidate {
 #[serde(default)]
 pub struct Components {
     pub primary_number: String,
-    pub street_prediction: String,
     pub street_name: String,
+    pub street_predirection: String,
     pub street_postdirection: String,
     pub street_suffix: String,
     pub secondary_number: String,


### PR DESCRIPTION
According to the smarty docs for candidate components it should be predirection see here: https://www.smarty.com/docs/cloud/us-street-api#components