### PR TITLE
Mae/reverse geo error handling

### DIFF
--- a/smarty-rust-sdk/src/sdk/error.rs
+++ b/smarty-rust-sdk/src/sdk/error.rs
@@ -10,7 +10,12 @@ pub enum SmartyError {
     Middleware(#[from] anyhow::Error),
     #[error("failed to parse url")]
     Parse(#[from] url::ParseError),
-    #[error("http error {code}: {detail}")]
-    HttpError { code: StatusCode, detail: String },
+    #[error("http error {code}: {message}")]
+    HttpError {
+        code: StatusCode,
+        message: String,
+        body: String,
+    },
     #[error("validation error: {0}")]
     ValidationError(String),
+}

--- a/smarty-rust-sdk/src/sdk/error.rs
+++ b/smarty-rust-sdk/src/sdk/error.rs
@@ -10,8 +10,7 @@ pub enum SmartyError {
     Middleware(#[from] anyhow::Error),
     #[error("failed to parse url")]
     Parse(#[from] url::ParseError),
-    #[error("http error")]
+    #[error("http error {code}: {detail}")]
     HttpError { code: StatusCode, detail: String },
     #[error("validation error: {0}")]
     ValidationError(String),
-}

--- a/smarty-rust-sdk/src/sdk/mod.rs
+++ b/smarty-rust-sdk/src/sdk/mod.rs
@@ -50,14 +50,48 @@ pub(crate) async fn parse_response_json<C: DeserializeOwned>(
     if !response.status().is_success() {
         let status_code = response.status();
         let body = response.text().await?;
+        let message = extract_error_message(&body).unwrap_or_else(|| body.clone());
 
         return Err(SmartyError::HttpError {
             code: status_code,
-            detail: body,
+            message,
+            body,
         });
     }
 
     Ok(response.json::<C>().await?)
+}
+
+/// Pulls a human-readable message out of a Smarty API error body, which has the
+/// shape `{"errors":[{"message":"..."}]}`. The `message` values are joined with
+/// a space. Returns `None` if the body is empty, unparseable, or carries no
+/// non-empty messages, leaving the caller to fall back to the raw body.
+fn extract_error_message(body: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct ErrorBody {
+        errors: Vec<ApiError>,
+    }
+    #[derive(serde::Deserialize)]
+    struct ApiError {
+        #[serde(default)]
+        message: String,
+    }
+
+    let parsed: ErrorBody = serde_json::from_str(body).ok()?;
+    let message = parsed
+        .errors
+        .into_iter()
+        .map(|e| e.message)
+        .filter(|m| !m.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let message = message.trim().to_string();
+
+    if message.is_empty() {
+        None
+    } else {
+        Some(message)
+    }
 }
 
 pub(crate) async fn send_request<C: DeserializeOwned>(
@@ -96,9 +130,37 @@ mod tests {
     use crate::sdk::authentication::SecretKeyCredential;
     use crate::sdk::batch::Batch;
     use crate::sdk::client::Client;
+    use crate::sdk::extract_error_message;
     use crate::sdk::options::OptionsBuilder;
     use crate::sdk::VERSION;
     use reqwest::header::USER_AGENT;
+
+    #[test]
+    fn extract_error_message_pulls_api_messages() {
+        let body = r#"{"errors":[{"message":"latitude is out of range"}]}"#;
+        assert_eq!(
+            extract_error_message(body).as_deref(),
+            Some("latitude is out of range")
+        );
+    }
+
+    #[test]
+    fn extract_error_message_joins_multiple_messages() {
+        let body = r#"{"errors":[{"message":"first"},{"message":"second"}]}"#;
+        assert_eq!(extract_error_message(body).as_deref(), Some("first second"));
+    }
+
+    #[test]
+    fn extract_error_message_falls_back_when_unusable() {
+        // empty body, malformed json, and a body missing the field all yield None
+        assert_eq!(extract_error_message(""), None);
+        assert_eq!(extract_error_message("not json"), None);
+        assert_eq!(extract_error_message(r#"{"errors":[]}"#), None);
+        assert_eq!(
+            extract_error_message(r#"{"errors":[{"message":"  "}]}"#),
+            None
+        );
+    }
 
     #[test]
     fn batch_test() {

--- a/smarty-rust-sdk/tests/us_reverse_geo_http.rs
+++ b/smarty-rust-sdk/tests/us_reverse_geo_http.rs
@@ -1,0 +1,90 @@
+//! HTTP-layer tests for the US Reverse Geo client, driven by wiremock.
+//!
+//! The SDK does no client-side latitude/longitude validation, so an
+//! out-of-range coordinate is sent to the API, which answers 422. These tests
+//! pin how that error is surfaced: captured as `SmartyError::HttpError` with
+//! the status code and response body preserved, and rendered into the Display
+//! message. They run without credentials, so they're part of the default
+//! `cargo test` run.
+
+use smarty_rust_sdk::sdk::error::SmartyError;
+use smarty_rust_sdk::sdk::options::OptionsBuilder;
+use smarty_rust_sdk::us_reverse_geo_api::client::USReverseGeoClient;
+use smarty_rust_sdk::us_reverse_geo_api::lookup::Lookup;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn client_for(server: &MockServer) -> USReverseGeoClient {
+    let options = OptionsBuilder::new(None)
+        .with_base_url(&server.uri())
+        .build();
+    USReverseGeoClient::new(options).unwrap()
+}
+
+#[tokio::test]
+async fn out_of_range_latitude_surfaces_http_error_with_code_and_body() {
+    let server = MockServer::start().await;
+
+    let body = "{\"errors\":[{\"message\":\"latitude is out of range\"}]}";
+
+    Mock::given(method("GET"))
+        .and(path("/lookup"))
+        .respond_with(ResponseTemplate::new(422).set_body_string(body))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let mut lookup = Lookup {
+        latitude: 99937.42251134855708,
+        longitude: -122.08412869140541,
+        ..Default::default()
+    };
+
+    let err = client
+        .send(&mut lookup)
+        .await
+        .expect_err("422 should be an error");
+
+    match err {
+        SmartyError::HttpError { code, detail } => {
+            assert_eq!(code.as_u16(), 422);
+            assert_eq!(detail, body, "response body should be preserved verbatim");
+        }
+        other => panic!("expected HttpError, got {other:?}"),
+    }
+
+    // results are left untouched on error
+    assert!(lookup.results.results.is_empty());
+}
+
+#[tokio::test]
+async fn http_error_display_includes_status_and_detail() {
+    let server = MockServer::start().await;
+
+    let body = "latitude is out of range";
+
+    Mock::given(method("GET"))
+        .and(path("/lookup"))
+        .respond_with(ResponseTemplate::new(422).set_body_string(body))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let mut lookup = Lookup {
+        latitude: 99937.42251134855708,
+        longitude: -122.08412869140541,
+        ..Default::default()
+    };
+
+    let err = client
+        .send(&mut lookup)
+        .await
+        .expect_err("422 should be an error");
+
+    // Display must carry the actionable info, not the old bare "http error".
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("422") && rendered.contains(body),
+        "Display dropped status/detail: {rendered:?}"
+    );
+}

--- a/smarty-rust-sdk/tests/us_reverse_geo_http.rs
+++ b/smarty-rust-sdk/tests/us_reverse_geo_http.rs
@@ -35,8 +35,8 @@ async fn out_of_range_latitude_surfaces_http_error_with_code_and_body() {
 
     let client = client_for(&server);
     let mut lookup = Lookup {
-        latitude: 99937.42251134855708,
-        longitude: -122.08412869140541,
+        latitude: 99_937.422_511_348_56,
+        longitude: -122.084_128_691_405_41,
         ..Default::default()
     };
 
@@ -46,9 +46,17 @@ async fn out_of_range_latitude_surfaces_http_error_with_code_and_body() {
         .expect_err("422 should be an error");
 
     match err {
-        SmartyError::HttpError { code, detail } => {
+        SmartyError::HttpError {
+            code,
+            message,
+            body: raw_body,
+        } => {
             assert_eq!(code.as_u16(), 422);
-            assert_eq!(detail, body, "response body should be preserved verbatim");
+            assert_eq!(raw_body, body, "response body should be preserved verbatim");
+            assert_eq!(
+                message, "latitude is out of range",
+                "message should be parsed from errors[].message"
+            );
         }
         other => panic!("expected HttpError, got {other:?}"),
     }
@@ -71,8 +79,8 @@ async fn http_error_display_includes_status_and_detail() {
 
     let client = client_for(&server);
     let mut lookup = Lookup {
-        latitude: 99937.42251134855708,
-        longitude: -122.08412869140541,
+        latitude: 99_937.422_511_348_56,
+        longitude: -122.084_128_691_405_41,
         ..Default::default()
     };
 


### PR DESCRIPTION
Made 422 and other 400 errors (aside from 429) return the actual error info, added a function to parse out the error message more legibly, and added testing for both of the previous.